### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Node CI
+permissions:
+  contents: read
 
 on: [pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/opengovsg/changesets-action/security/code-scanning/1](https://github.com/opengovsg/changesets-action/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimum required permissions for the workflow. Since the workflow only performs read operations (e.g., checking out the repository and installing dependencies), we will set `contents: read`. This ensures that the workflow has only the permissions it needs and no more.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
